### PR TITLE
Add basic dependency injection mechanism

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -3506,6 +3506,11 @@
       "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz",
       "integrity": "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w=="
     },
+    "reflect-metadata": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
+      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
+    },
     "regex-not": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -11,6 +11,7 @@
     "dotenv": "^8.2.0",
     "dotenv-webpack": "^5.0.1",
     "node-sass": "^5.0.0",
+    "reflect-metadata": "^0.1.13",
     "sass": "^1.29.0",
     "sass-loader": "^10.0.5",
     "style-loader": "^2.0.0",

--- a/client/src/Error/ErrorController.ts
+++ b/client/src/Error/ErrorController.ts
@@ -1,6 +1,10 @@
-import {Log} from '../../../shared/Util/Log';
+import { Log } from "../../../shared/Util/Log";
+import { Injectable } from "../injection";
 
+@Injectable()
 export class ErrorController {
+  public constructor() {}
+
   public handleError(error: unknown): void {
     Log.error(error);
   }

--- a/client/src/Lobby/LobbyController.ts
+++ b/client/src/Lobby/LobbyController.ts
@@ -2,7 +2,9 @@ import {RouterController} from '../Router/RouterController';
 import {LobbyView} from './LobbyView';
 import {RoomController} from '../Room/RoomController';
 import {ErrorController} from '../Error/ErrorController';
+import { Injectable } from '../injection';
 
+@Injectable()
 export class LobbyController {
   constructor(view: LobbyView, readonly errorController: ErrorController, router: RouterController, room: RoomController) {
     view.onLobbyFormSubmit = async () => {

--- a/client/src/Lobby/LobbyView.ts
+++ b/client/src/Lobby/LobbyView.ts
@@ -1,17 +1,19 @@
-import './lobby.scss';
-import {Dom} from '../View/Dom';
+import "./lobby.scss";
+import { Dom } from "../View/Dom";
+import { Injectable } from "../injection";
 
+@Injectable()
 export class LobbyView {
   private readonly lobbyForm = this.dom.lobbyForm;
   private readonly usernameInput = this.dom.usernameInput;
   private readonly roomNameInput = this.dom.roomNameInput;
 
   constructor(private readonly dom: Dom) {
-    this.lobbyForm.addEventListener('submit', (e) => e.preventDefault());
+    this.lobbyForm.addEventListener("submit", (e) => e.preventDefault());
   }
 
   set onLobbyFormSubmit(value: () => void) {
-    this.lobbyForm.addEventListener('submit', value);
+    this.lobbyForm.addEventListener("submit", value);
   }
 
   get username(): string {
@@ -29,4 +31,12 @@ export class LobbyView {
   set roomName(value: string) {
     this.roomNameInput.value = value;
   }
+}
+
+class Dependency {
+  constructor(
+    public readonly name: string,
+    public readonly con: Function,
+    public readonly subDeps: string[]
+  ) {}
 }

--- a/client/src/Room/RoomController.ts
+++ b/client/src/Room/RoomController.ts
@@ -14,7 +14,9 @@ import {
   UserListChangedMessage,
 } from '../../../shared/Messages';
 import {ErrorController} from '../Error/ErrorController';
+import { Injectable } from '../injection';
 
+@Injectable()
 export class RoomController implements MessageListener, PeerConnectionListener {
   private static readonly mediaConstraints = {
     // TODO: this was copy pasted, maybe improve

--- a/client/src/Room/RoomView.ts
+++ b/client/src/Room/RoomView.ts
@@ -1,7 +1,9 @@
 import "./room.scss";
 import {ClassName, Dom} from "../View/Dom";
 import { User } from "../../../shared/User";
+import { Injectable } from "../injection";
 
+@Injectable()
 export class RoomView {
   private readonly chatHistoryList = this.dom.chatHistoryList;
   private readonly attendeesList = this.dom.attendeesList;

--- a/client/src/Router/RouterController.ts
+++ b/client/src/Router/RouterController.ts
@@ -1,6 +1,8 @@
 import {RouterView} from './RouterView';
 import {ErrorController} from '../Error/ErrorController';
+import { Injectable } from '../injection';
 
+@Injectable()
 export class RouterController {
   constructor(readonly view: RouterView, readonly errorController: ErrorController) {
   }

--- a/client/src/Router/RouterView.ts
+++ b/client/src/Router/RouterView.ts
@@ -1,5 +1,7 @@
+import { Injectable } from '../injection';
 import {ClassName, Dom} from '../View/Dom';
 
+@Injectable()
 export class RouterView {
   private readonly lobbyRoot = this.dom.lobbyRoot;
   private readonly roomRoot = this.dom.roomRoot;

--- a/client/src/injection.ts
+++ b/client/src/injection.ts
@@ -13,19 +13,18 @@ export const Injectable = (): GenericClassDecorator<Type<unknown>> => {
 /**
  * The @type {DependencyContainer} class can be used for dependency
  * injection and inversion of control.
- * 
+ *
  * Bootstrapping creates instances of each class and it's dependencies
  * automagically.
  */
 export class DependencyContainer {
   private resolvedClasses = new Map();
 
-
   /**
    * This method allows for manual installation of a dependency.
    * This can be useful in cases where a dependency is required by
    * other classes can not be created automatically itself.
-   *  
+   *
    * @param target The type that should be resolvable
    * @param instance The concrete instance that will be resolved
    */
@@ -35,11 +34,11 @@ export class DependencyContainer {
 
   /**
    * Returns the resolved instance of a target type.
-   * 
+   *
    * @example
-   * 
+   *
    *  let service = get<IServiceName>(IServiceName);
-   * 
+   *
    * @param target The target type that should be resolved
    */
   public get<T>(target: Type<unknown>): T {
@@ -50,20 +49,25 @@ export class DependencyContainer {
    * Bootstraps all classes handed in to this method.
    * This guarantees the creation of each class and it's
    * dependencies.
-   * 
+   *
    * @param classes An array of the classes to create
    */
   public bootstrap(classes: Type<unknown>[]) {
     classes.forEach((c) => this.get<unknown>(c));
   }
 
-  private resolve<T>(target: Type<unknown>, dependencyTree: Type<unknown>[]): T {
+  private resolve<T>(
+    target: Type<unknown>,
+    dependencyTree: Type<unknown>[]
+  ): T {
     if (this.resolvedClasses.has(target)) {
       return this.resolvedClasses.get(target);
     }
 
     if (dependencyTree.includes(target)) {
-      throw new Error("=== CIRCULAR DEPENDENCY DETECTED ====");
+      throw new Error(
+        `DependencyContainer has detected a circular dependency with '${target}' class involved.`
+      );
     }
 
     dependencyTree.push(target);

--- a/client/src/injection.ts
+++ b/client/src/injection.ts
@@ -1,0 +1,56 @@
+import "reflect-metadata";
+
+export interface Type<T> {
+  new (...args: any[]): T;
+}
+
+export type GenericClassDecorator<T> = (target: T) => void;
+
+export const Injectable = (): GenericClassDecorator<Type<any>> => {
+  return (target) => {};
+};
+
+export class DependencyContainer {
+  private resolvedClasses = new Map();
+
+  public install(target: Type<any>, instance: any) {
+    this.resolvedClasses.set(target, instance);
+  }
+
+  private resolve<T>(target: Type<any>, dependencyTree: Type<any>[]): T {
+    if (this.resolvedClasses.has(target)) {
+      return this.resolvedClasses.get(target);
+    }
+
+    if (dependencyTree.includes(target)) {
+      throw new Error("=== CIRCULAR DEPENDENCY DETECTED ====");
+    }
+
+    dependencyTree.push(target);
+
+    var paramTypes = Reflect.getMetadata("design:paramtypes", target);
+
+    if (paramTypes == null) {
+      throw new Error(
+        `Type "${target.name}" not found. Did you forget to add @Injectable()?`
+      );
+    }
+
+    var params = paramTypes.map((p: any) =>
+      this.resolve<any>(p, dependencyTree)
+    );
+
+    const instance = new target(...params);
+
+    this.resolvedClasses.set(target, instance);
+    return instance;
+  }
+
+  public get<T>(target: Type<any>): T {
+    return this.resolve(target, []);
+  }
+
+  public bootstrap(classes: Type<any>[]) {
+    classes.forEach((c) => this.get<any>(c));
+  }
+}

--- a/client/src/injection.ts
+++ b/client/src/injection.ts
@@ -1,23 +1,22 @@
 import "reflect-metadata";
 
-export interface Type<T> {
-  new (...args: any[]): T;
+interface Type<T> {
+  new (...args: unknown[]): T;
 }
+type GenericClassDecorator<T> = (target: T) => void;
 
-export type GenericClassDecorator<T> = (target: T) => void;
-
-export const Injectable = (): GenericClassDecorator<Type<any>> => {
-  return (target) => {};
+export const Injectable = (): GenericClassDecorator<Type<unknown>> => {
+  return (_) => {};
 };
 
 export class DependencyContainer {
   private resolvedClasses = new Map();
 
-  public install(target: Type<any>, instance: any) {
+  public install(target: Type<unknown>, instance: unknown) {
     this.resolvedClasses.set(target, instance);
   }
 
-  private resolve<T>(target: Type<any>, dependencyTree: Type<any>[]): T {
+  private resolve<T>(target: Type<unknown>, dependencyTree: Type<unknown>[]): T {
     if (this.resolvedClasses.has(target)) {
       return this.resolvedClasses.get(target);
     }
@@ -28,7 +27,7 @@ export class DependencyContainer {
 
     dependencyTree.push(target);
 
-    var paramTypes = Reflect.getMetadata("design:paramtypes", target);
+    const paramTypes = Reflect.getMetadata("design:paramtypes", target);
 
     if (paramTypes == null) {
       throw new Error(
@@ -36,21 +35,21 @@ export class DependencyContainer {
       );
     }
 
-    var params = paramTypes.map((p: any) =>
-      this.resolve<any>(p, dependencyTree)
+    const params = paramTypes.map((p: Type<unknown>) =>
+      this.resolve<unknown>(p, dependencyTree)
     );
 
     const instance = new target(...params);
 
     this.resolvedClasses.set(target, instance);
-    return instance;
+    return instance as T;
   }
 
-  public get<T>(target: Type<any>): T {
+  public get<T>(target: Type<unknown>): T {
     return this.resolve(target, []);
   }
 
-  public bootstrap(classes: Type<any>[]) {
-    classes.forEach((c) => this.get<any>(c));
+  public bootstrap(classes: Type<unknown>[]) {
+    classes.forEach((c) => this.get<unknown>(c));
   }
 }

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -8,7 +8,7 @@ import { ErrorController } from "./Error/ErrorController";
 import { DependencyContainer } from "./injection";
 
 try {
-  var container = new DependencyContainer();
+  const container = new DependencyContainer();
   container.install(Dom, new Dom(document));
   
   const controllers = [

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1,23 +1,24 @@
-import './main.scss';
-import {RoomController} from './Room/RoomController';
-import {RouterController} from './Router/RouterController';
-import {RouterView} from './Router/RouterView';
-import {LobbyController} from './Lobby/LobbyController';
-import {LobbyView} from './Lobby/LobbyView';
-import {RoomView} from './Room/RoomView';
-import {Dom} from './View/Dom';
-import {Log} from '../../shared/Util/Log';
-import {ErrorController} from './Error/ErrorController';
+import "./main.scss";
+import { RoomController } from "./Room/RoomController";
+import { RouterController } from "./Router/RouterController";
+import { LobbyController } from "./Lobby/LobbyController";
+import { Dom } from "./View/Dom";
+import { Log } from "../../shared/Util/Log";
+import { ErrorController } from "./Error/ErrorController";
+import { DependencyContainer } from "./injection";
 
 try {
-  const dom = new Dom(document);
-  const routerView = new RouterView(dom);
-  const loginView = new LobbyView(dom);
-  const roomView = new RoomView(dom);
-  const errorController = new ErrorController();
-  const routerController = new RouterController(routerView, errorController);
-  const roomController = new RoomController(roomView, errorController);
-  const loginController = new LobbyController(loginView, errorController, routerController, roomController);
+  var container = new DependencyContainer();
+  container.install(Dom, new Dom(document));
+  
+  const controllers = [
+    ErrorController,
+    RouterController,
+    RoomController,
+    LobbyController,
+  ];
+  container.bootstrap(controllers);
+
 } catch (e) {
   alert(`FATAL INITIALIZATION ERROR: ${e}`);
   Log.error(e);

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -18,7 +18,9 @@
     "isolatedModules": true,
     "noFallthroughCasesInSwitch": true,
     "removeComments": true,
-    "sourceMap": true
+    "sourceMap": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
   },
   "include": [
     "src",

--- a/server/src/Connection.ts
+++ b/server/src/Connection.ts
@@ -1,10 +1,14 @@
+import { type } from "os";
 import WebSocket from "ws";
 import { User } from "../../shared/User";
 import { Room } from "./Room";
+
+export type ConnectionId = number;
 
 export class Connection {
   user?: User;
   room?: Room;
 
-  constructor(public socket: WebSocket, public id: number) {}
+  constructor(public socket: WebSocket, public id: ConnectionId) {}
 }
+

--- a/server/src/Connection.ts
+++ b/server/src/Connection.ts
@@ -1,4 +1,3 @@
-import { type } from "os";
 import WebSocket from "ws";
 import { User } from "../../shared/User";
 import { Room } from "./Room";

--- a/server/src/ConnectionGroup.ts
+++ b/server/src/ConnectionGroup.ts
@@ -1,6 +1,6 @@
-import { Connection } from "./Connection";
 
 import WebSocket from "ws";
+import { Connection, ConnectionId } from "./Connection";
 import { BaseMessage } from "../../shared/Messages";
 import { User } from "../../shared/User";
 import { Log } from "../../shared/Util/Log";
@@ -11,7 +11,7 @@ import { Log } from "../../shared/Util/Log";
  * sending to a specific user in the group or getting all users.
  */
 export class ConnectionGroup {
-  protected connections = new Map<number, Connection>();
+  protected connections = new Map<ConnectionId, Connection>();
 
   addConnection(con: Connection) {
     this.connections.set(con.id, con);
@@ -21,7 +21,7 @@ export class ConnectionGroup {
     this.connections.delete(con.id);
   }
 
-  broadcast(message: BaseMessage, except?: number) {
+  broadcast(message: BaseMessage, except?: ConnectionId) {
     for (const [_, con] of this.connections) {
       if (con.id == except && except != null) {
         continue;


### PR DESCRIPTION
Die Frage ist, ob es für die Lehrveranstaltung erlaubt ist die reflect-metadata typescript library zu inkludieren. Diese erlaubt das abrufen von Metadaten die von TypeScript mit in den ES6 output gepackt wird.

Ansonsten erlaubt `@Injectable()`, dass Dependencies automatisch gefunden und in der richtigen Reihenfolge übergeben werden.